### PR TITLE
Kimchi + KZG prover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /proof.json
+/proof.mpk
 monitor/priv/native/libverifier.so

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "verifier_circuit/o1js"]
 	path = verifier_circuit/o1js
-	url = https://github.com/o1-labs/o1js.git
+	url = https://github.com/lambdaclass/o1js.git
+	branch = kzg_prover

--- a/verifier_circuit/package.json
+++ b/verifier_circuit/package.json
@@ -40,9 +40,9 @@
     "eslint-plugin-o1js": "^0.4.0",
     "jest": "^28.1.3",
     "lint-staged": "^11.0.1",
+    "o1js": "file:o1js",
     "prettier": "^2.3.2",
     "ts-jest": "^28.0.8",
-    "typescript": "^4.9.5",
-    "o1js": "file:o1js"
+    "typescript": "^4.9.5"
   }
 }

--- a/verifier_circuit/src/main.ts
+++ b/verifier_circuit/src/main.ts
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync } from "fs";
-import { Field, Group, Scalar } from "o1js";
+import { Group, Scalar } from "o1js";
 import { Verifier } from "./verifier/verifier.js";
 import { exit } from "process";
 
@@ -39,7 +39,6 @@ let keypair = await Verifier.generateKeypair();
 
 console.log("Proving with Ethereum backend...");
 let proofKZG = await Verifier.proveKZG([], public_input, keypair);
-console.dir(proofKZG, { depth: null });
 
 console.log("Proving with Mina backend...");
 let proof = await Verifier.prove([], public_input, keypair);
@@ -51,13 +50,8 @@ if (!isValid) {
     exit();
 }
 
-console.log("Writing proof into file...");
-
-// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json
-const replacer = (_key: string, value: any) =>
-    typeof value === "bigint" ? value.toString() : value;
-
-writeFileSync("../proof.json", JSON.stringify(proof, replacer));
+console.log("Writing KZG proof into file...");
+writeFileSync("../proof.mpk", proofKZG);
 
 // ----------------------------------------------------
 console.log('Shutting down O1JS...');

--- a/verifier_circuit/src/main.ts
+++ b/verifier_circuit/src/main.ts
@@ -38,7 +38,8 @@ let public_input = [sg, sg_scalar, expected];
 let keypair = await Verifier.generateKeypair();
 
 console.log("Proving with Ethereum backend...");
-await Verifier.proveKZG([], public_input, keypair);
+let proofKZG = await Verifier.proveKZG([], public_input, keypair);
+console.dir(proofKZG, { depth: null });
 
 console.log("Proving with Mina backend...");
 let proof = await Verifier.prove([], public_input, keypair);

--- a/verifier_circuit/src/main.ts
+++ b/verifier_circuit/src/main.ts
@@ -37,7 +37,10 @@ let public_input = [sg, sg_scalar, expected];
 
 let keypair = await Verifier.generateKeypair();
 
-console.log("Proving...");
+console.log("Proving with Ethereum backend...");
+await Verifier.proveKZG([], public_input, keypair);
+
+console.log("Proving with Mina backend...");
 let proof = await Verifier.prove([], public_input, keypair);
 console.log("Verifying...");
 let isValid = await Verifier.verify(public_input, keypair.verificationKey(), proof);


### PR DESCRIPTION
- Replaces proof to be serialized so that it stores proofs with Ethereum backend
  - For now, it only stores the URS
- Updates o1js submodules so that it points to `kzg_prover` branch
- Sorts packages declaration

For now, KZG prover only generates dummy proofs. This PR is necessary to integrate the verifier circuit, the KZG prover and the verifier contract.