### PR TITLE
EC operations with foreign fields

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "verifier_circuit/o1js"]
 	path = verifier_circuit/o1js
 	url = https://github.com/lambdaclass/o1js.git
-	branch = wasm_kzg_prover
+	branch = foreign_ec_ops
 [submodule "kzg_prover/proof-systems"]
 	path = kzg_prover/proof-systems
 	url = https://github.com/lambdaclass/proof-systems.git

--- a/kzg_prover/src/main.rs
+++ b/kzg_prover/src/main.rs
@@ -4,44 +4,31 @@ use std::{fs, ops::Neg};
 
 use ark_bn254::{G1Affine, G2Affine};
 use ark_ec::{
-    msm::VariableBaseMSM, short_weierstrass_jacobian::GroupAffine, AffineCurve, PairingEngine,
-    ProjectiveCurve,
+    msm::VariableBaseMSM, short_weierstrass_jacobian::GroupAffine, AffineCurve, ProjectiveCurve,
 };
 use ark_ff::PrimeField;
 use ark_poly::{
-    univariate::DenseOrSparsePolynomial, univariate::DensePolynomial, EvaluationDomain,
-    Evaluations, Polynomial, Radix2EvaluationDomain, UVPolynomial,
+    univariate::DensePolynomial, Evaluations, Polynomial, Radix2EvaluationDomain, UVPolynomial,
 };
 use ark_serialize::{CanonicalSerialize, SerializationError};
 use ark_std::{
-    rand::{self, rngs::StdRng, SeedableRng},
+    rand::{rngs::StdRng, SeedableRng},
     UniformRand,
 };
-use hex;
-use kimchi::{
-    circuits::{
-        constraints::ConstraintSystem,
-        domains::EvaluationDomains,
-        gate::{CircuitGate, GateType},
-        polynomials::generic::testing::create_circuit,
-    },
-    o1_utils::FieldHelpers,
+use kimchi::circuits::{
+    constraints::ConstraintSystem,
+    domains::EvaluationDomains,
+    gate::{CircuitGate, GateType},
 };
 use num_traits::{One, Zero};
 use poly_commitment::{
     commitment::{combine_commitments, combine_evaluations, Evaluation},
-    evaluation_proof::{combine_polys, DensePolynomialOrEvaluations},
+    evaluation_proof::DensePolynomialOrEvaluations,
     pairing_proof::{PairingProof, PairingSRS},
     srs::SRS,
-    PolyComm, SRS as _,
+    SRS as _,
 };
 use snarky_gate::SnarkyGate;
-
-type PolynomialsToCombine<'a> = &'a [(
-    DensePolynomialOrEvaluations<'a, ark_bn254::Fr, Radix2EvaluationDomain<ark_bn254::Fr>>,
-    Option<usize>,
-    PolyComm<ark_bn254::Fr>,
-)];
 
 fn main() {
     let rng = &mut StdRng::from_seed([0u8; 32]);
@@ -136,11 +123,7 @@ fn main() {
     points_serialized.extend(quotient_serialized);
     points_serialized.extend(divisor_serialized);
 
-    fs::write(
-        "../eth_verifier/proof.mpk",
-        points_serialized,
-    )
-    .unwrap();
+    fs::write("../eth_verifier/proof.mpk", points_serialized).unwrap();
 
     println!(
         "Is KZG proof valid?: {:?}",
@@ -200,9 +183,7 @@ fn create_selector_dense_polynomials(
     domain: EvaluationDomains<ark_ff::Fp256<ark_bn254::FrParameters>>,
 ) -> Vec<DensePolynomial<ark_ff::Fp256<ark_bn254::FrParameters>>> {
     let foreign_field_add_selector =
-        selector_polynomial(GateType::ForeignFieldAdd, &cs.gates, &domain, &domain.d8);
-    let foreign_field_add_selector8 =
-        foreign_field_add_selector.evaluate_over_domain_by_ref(domain.d8);
+        selector_polynomial(GateType::ForeignFieldAdd, &cs.gates, &domain);
 
     let generic_selector =
         Evaluations::<ark_bn254::Fr, Radix2EvaluationDomain<ark_bn254::Fr>>::from_vec_and_domain(
@@ -219,8 +200,6 @@ fn create_selector_dense_polynomials(
             cs.domain.d1,
         )
         .interpolate();
-
-    let generic_selector4 = generic_selector.evaluate_over_domain_by_ref(cs.domain.d4);
 
     let polynomials: Vec<_> = vec![foreign_field_add_selector, generic_selector];
     polynomials
@@ -239,43 +218,6 @@ fn create_srs(
         full_srs: srs,
         verifier_srs,
     }
-}
-
-fn create_proof(
-    srs: &PairingSRS<ark_ec::bn::Bn<ark_bn254::Parameters>>,
-    plnms: PolynomialsToCombine, // vector of polynomial with optional degree bound and commitment randomness
-    elm: &[ark_bn254::Fr],       // vector of evaluation points
-    polyscale: ark_bn254::Fr,    // scaling factor for polynoms
-) -> Option<PairingProof<ark_ec::bn::Bn<ark_bn254::Parameters>>> {
-    let (p, blinding_factor) = combine_polys::<
-        GroupAffine<ark_bn254::g1::Parameters>,
-        Radix2EvaluationDomain<ark_bn254::Fr>,
-    >(plnms, polyscale, srs.full_srs.g.len());
-    let evals: Vec<_> = elm.iter().map(|pt| p.evaluate(pt)).collect();
-
-    let quotient_poly = {
-        let eval_polynomial = eval_polynomial(elm, &evals);
-        let divisor_polynomial = divisor_polynomial(elm);
-        let numerator_polynomial = &p - &eval_polynomial;
-        let (quotient, remainder) = DenseOrSparsePolynomial::divide_with_q_and_r(
-            &numerator_polynomial.into(),
-            &divisor_polynomial.into(),
-        )?;
-        if !remainder.is_zero() {
-            return None;
-        }
-        quotient
-    };
-
-    let quotient = srs
-        .full_srs
-        .commit_non_hiding(&quotient_poly, 1, None)
-        .unshifted[0];
-
-    Some(PairingProof {
-        quotient,
-        blinding: blinding_factor,
-    })
 }
 
 /// The polynomial that evaluates to each of `evals` for the respective `elm`s.
@@ -318,7 +260,6 @@ fn selector_polynomial(
     gate_type: GateType,
     gates: &[CircuitGate<ark_bn254::Fr>],
     domain: &EvaluationDomains<ark_bn254::Fr>,
-    target_domain: &Radix2EvaluationDomain<ark_bn254::Fr>,
 ) -> DensePolynomial<ark_bn254::Fr> {
     // Coefficient form
     Evaluations::<_, Radix2EvaluationDomain<_>>::from_vec_and_domain(

--- a/kzg_prover/src/snarky_gate.rs
+++ b/kzg_prover/src/snarky_gate.rs
@@ -38,6 +38,8 @@ impl Into<CircuitGate<ark_bn254::Fr>> for SnarkyGate {
             GateType::Generic
         } else if self.r#type == "ForeignFieldAdd" {
             GateType::ForeignFieldAdd
+        } else if self.r#type == "ForeignFieldMul" {
+            GateType::ForeignFieldMul
         } else if self.r#type == "Zero" {
             GateType::Zero
         } else if self.r#type == "RangeCheck0" {

--- a/verifier_circuit/package-lock.json
+++ b/verifier_circuit/package-lock.json
@@ -11071,7 +11071,7 @@
       }
     },
     "o1js": {
-      "version": "0.13.0",
+      "version": "0.13.1",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/verifier_circuit/src/SRS.ts
+++ b/verifier_circuit/src/SRS.ts
@@ -34,16 +34,16 @@ interface LagrangeBaseJSON {
     }[]
 }
 
-export class SRS<F extends ForeignField> {
+export class SRS {
     /// The vector of group elements for committing to polynomials in coefficient form
-    g: ForeignGroup<ForeignField>[];
+    g: ForeignGroup[];
     /// A group element used for blinding commitments
-    h: ForeignGroup<ForeignField>;
+    h: ForeignGroup;
     /// Commitments to Lagrange bases, per domain size
-    lagrangeBases: Map<number, PolyComm<ForeignGroup<ForeignField>>[]>
+    lagrangeBases: Map<number, PolyComm<ForeignGroup>[]>
 
     static createFromJSON() {
-        let g: ForeignGroup<ForeignField>[] = g_json.map((g_i_json) => this.#createGroupFromJSON(g_i_json));
+        let g: ForeignGroup[] = g_json.map((g_i_json) => this.#createGroupFromJSON(g_i_json));
         let h = this.#createGroupFromJSON(h_json);
         return new SRS(g, h);
     }
@@ -63,7 +63,7 @@ export class SRS<F extends ForeignField> {
     //     return new Map<number, PolyComm<ForeignGroup>[]>([[32, lagrange_bases]]);
     // }
 
-    constructor(g: ForeignGroup<ForeignField>[], h: ForeignGroup<ForeignField>) {
+    constructor(g: ForeignGroup[], h: ForeignGroup) {
         this.g = g;
         this.h = h;
         // this.lagrangeBases = SRS.#createLagrangeBasesFromJSON(lagrange_bases_json);

--- a/verifier_circuit/src/SRS.ts
+++ b/verifier_circuit/src/SRS.ts
@@ -1,9 +1,7 @@
-import lagrange_bases_json from "../test/lagrange_bases.json" assert { type: "json" };
-import { Field, Group, Scalar } from "o1js";
-import { BlindedCommitment, PolyComm } from "./poly_commitment/commitment.js";
+import { PolyComm } from "./poly_commitment/commitment.js";
 import { readFileSync } from "fs";
-import { ForeignGroup } from "./foreign_fields/foreign_group.js";
 import { ForeignField } from "./foreign_fields/foreign_field.js";
+import { ForeignGroup } from "o1js";
 
 let srs_json;
 try {
@@ -36,16 +34,16 @@ interface LagrangeBaseJSON {
     }[]
 }
 
-export class SRS {
+export class SRS<F extends ForeignField> {
     /// The vector of group elements for committing to polynomials in coefficient form
-    g: ForeignGroup[];
+    g: ForeignGroup<ForeignField>[];
     /// A group element used for blinding commitments
-    h: ForeignGroup;
+    h: ForeignGroup<ForeignField>;
     /// Commitments to Lagrange bases, per domain size
-    lagrangeBases: Map<number, PolyComm<ForeignGroup>[]>
+    lagrangeBases: Map<number, PolyComm<ForeignGroup<ForeignField>>[]>
 
     static createFromJSON() {
-        let g: ForeignGroup[] = g_json.map((g_i_json) => this.#createGroupFromJSON(g_i_json));
+        let g: ForeignGroup<ForeignField>[] = g_json.map((g_i_json) => this.#createGroupFromJSON(g_i_json));
         let h = this.#createGroupFromJSON(h_json);
         return new SRS(g, h);
     }
@@ -65,7 +63,7 @@ export class SRS {
     //     return new Map<number, PolyComm<ForeignGroup>[]>([[32, lagrange_bases]]);
     // }
 
-    constructor(g: ForeignGroup[], h: ForeignGroup) {
+    constructor(g: ForeignGroup<ForeignField>[], h: ForeignGroup<ForeignField>) {
         this.g = g;
         this.h = h;
         // this.lagrangeBases = SRS.#createLagrangeBasesFromJSON(lagrange_bases_json);

--- a/verifier_circuit/src/main.ts
+++ b/verifier_circuit/src/main.ts
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync } from "fs";
-import { Provable } from "o1js";
+import { ForeignGroup, Provable } from "o1js";
 import { Verifier } from "./verifier/verifier.js";
 import { ForeignField } from "./foreign_fields/foreign_field.js";
 
@@ -30,6 +30,17 @@ let sg_x = ForeignField.from(inputs.sg[0]);
 let sg_y = ForeignField.from(inputs.sg[1]);
 let expected_x = ForeignField.from(inputs.expected[0])
 let expected_y = ForeignField.from(inputs.expected[1]);
+
+ForeignGroup.curve = [
+    "0", // a
+    "5", // b
+    "28948022309329048855892746252171976963363056481941560715954676764349967630337", // modulus
+    "1", // gen_x
+    "12418654782883325593414442427049395787963493412651469444558597405572177144507", // gen_y
+    "28948022309329048855892746252171976963363056481941647379679742748393362948097" // order
+];
+let sg = new ForeignGroup(sg_x, sg_y);
+console.dir(sg, { depth: null });
 
 console.log("Writing circuit into file...");
 let { gates } = Provable.constraintSystem(() => Verifier.main(sg_x, sg_y, expected_x, expected_y));

--- a/verifier_circuit/src/main.ts
+++ b/verifier_circuit/src/main.ts
@@ -2,8 +2,9 @@ import { readFileSync, writeFileSync } from "fs";
 import { ForeignGroup, Provable } from "o1js";
 import { Verifier } from "./verifier/verifier.js";
 import { ForeignField } from "./foreign_fields/foreign_field.js";
+import { ForeignScalar } from "./foreign_fields/foreign_scalar.js";
 
-let inputs: { sg: bigint[], expected: bigint[] };
+let inputs: { sg: bigint[], z1: bigint, expected: bigint[] };
 try {
     inputs = JSON.parse(readFileSync("./src/inputs.json", "utf-8"));
 } catch (e) {
@@ -14,9 +15,10 @@ try {
                 12368675093154914445558499940566677159678085503548847273105352744110357023892n,
                 13928325837869340024710380561463559827724328563792462791279614459373822978261n
             ],
+        z1: 4397093005605931442646816891053389885546297107331356987745997632505536565365n,
         expected: [
-            26065081609142297706924822385337762030176473849954371733717621265428419437080n,
-            25403161885444353082762527911380081866142600044068732571611330580992014688540n
+            5736868798632710640113734962596149556147058590963693818747480745427705446383n,
+            20393541083676616749487157095022413656498918946278576790740950610414772498695n
         ]
     };
 }
@@ -24,12 +26,6 @@ try {
 console.log('O1JS loaded');
 
 // ----------------------------------------------------
-
-// Convert JSON inputs to O1JS inputs so that we can pass them to the circuit
-let sg_x = ForeignField.from(inputs.sg[0]);
-let sg_y = ForeignField.from(inputs.sg[1]);
-let expected_x = ForeignField.from(inputs.expected[0])
-let expected_y = ForeignField.from(inputs.expected[1]);
 
 ForeignGroup.curve = [
     "0", // a
@@ -39,11 +35,20 @@ ForeignGroup.curve = [
     "12418654782883325593414442427049395787963493412651469444558597405572177144507", // gen_y
     "28948022309329048855892746252171976963363056481941647379679742748393362948097" // order
 ];
+
+// Convert JSON inputs to O1JS inputs so that we can pass them to the circuit
+let sg_x = ForeignField.from(inputs.sg[0]);
+let sg_y = ForeignField.from(inputs.sg[1]);
+let z1 = ForeignScalar.from(inputs.z1);
+let expected_x = ForeignField.from(inputs.expected[0])
+let expected_y = ForeignField.from(inputs.expected[1]);
+
 let sg = new ForeignGroup(sg_x, sg_y);
 let expected = new ForeignGroup(expected_x, expected_y);
 
+
 console.log("Writing circuit into file...");
-let { gates } = Provable.constraintSystem(() => Verifier.main(sg, expected));
+let { gates } = Provable.constraintSystem(() => Verifier.main(sg, z1, expected));
 writeFileSync("../kzg_prover/gates.json", JSON.stringify(gates));
 
 // ----------------------------------------------------

--- a/verifier_circuit/src/main.ts
+++ b/verifier_circuit/src/main.ts
@@ -40,10 +40,7 @@ ForeignGroup.curve = [
     "28948022309329048855892746252171976963363056481941647379679742748393362948097" // order
 ];
 let sg = new ForeignGroup(sg_x, sg_y);
-console.dir(sg, { depth: null });
-
 let expected = new ForeignGroup(expected_x, expected_y);
-console.dir(expected, { depth: null });
 
 console.log("Writing circuit into file...");
 let { gates } = Provable.constraintSystem(() => Verifier.main(sg, expected));

--- a/verifier_circuit/src/main.ts
+++ b/verifier_circuit/src/main.ts
@@ -42,8 +42,11 @@ ForeignGroup.curve = [
 let sg = new ForeignGroup(sg_x, sg_y);
 console.dir(sg, { depth: null });
 
+let expected = new ForeignGroup(expected_x, expected_y);
+console.dir(expected, { depth: null });
+
 console.log("Writing circuit into file...");
-let { gates } = Provable.constraintSystem(() => Verifier.main(sg_x, sg_y, expected_x, expected_y));
+let { gates } = Provable.constraintSystem(() => Verifier.main(sg, expected));
 writeFileSync("../kzg_prover/gates.json", JSON.stringify(gates));
 
 // ----------------------------------------------------

--- a/verifier_circuit/src/verifier/verifier.ts
+++ b/verifier_circuit/src/verifier/verifier.ts
@@ -135,6 +135,7 @@ export class Verifier extends Circuit {
     @circuitMain
     static main(@public_ sg_x: ForeignField, @public_ sg_y: ForeignField, @public_ expected_x: ForeignField, @public_ expected_y: ForeignField) {
         let sg = new ForeignGroup(sg_x, sg_y);
+        console.dir(sg, { depth: null });
         let actual = sg.add(h);
         let expected = new ForeignGroup(expected_x, expected_y);
         actual.assertEquals(expected);

--- a/verifier_circuit/src/verifier/verifier.ts
+++ b/verifier_circuit/src/verifier/verifier.ts
@@ -1,13 +1,11 @@
 import { readFileSync } from 'fs';
-import { circuitMain, Circuit, Group, Scalar, public_, Field } from 'o1js';
+import { circuitMain, Circuit, Group, Scalar, public_, Field, ForeignGroup } from 'o1js';
 import { PolyComm } from '../poly_commitment/commitment.js';
 import { SRS } from '../SRS.js';
 import { Sponge } from './sponge.js';
 import { Alphas } from '../alphas.js';
 import { Polynomial } from '../polynomial.js';
 import { Linearization, PolishToken } from '../prover/expr.js';
-import { ForeignScalar } from '../foreign_fields/foreign_scalar.js';
-import { ForeignGroup } from '../foreign_fields/foreign_group.js';
 import { ForeignField } from '../foreign_fields/foreign_field.js';
 
 let steps: bigint[][];
@@ -23,7 +21,7 @@ let { h } = SRS.createFromJSON();
 * Will contain information necessary for executing a verification
 */
 export class VerifierIndex {
-    srs: SRS
+    srs: SRS<ForeignField>
     domain_size: number
     domain_gen: Scalar
     /** number of public inputs */
@@ -133,11 +131,11 @@ export class Verifier extends Circuit {
     static readonly PERMUTATION_CONSTRAINTS: number = 3;
 
     @circuitMain
-    static main(@public_ sg_x: ForeignField, @public_ sg_y: ForeignField, @public_ expected_x: ForeignField, @public_ expected_y: ForeignField) {
-        let sg = new ForeignGroup(sg_x, sg_y);
+    static main(@public_ sg: ForeignGroup<ForeignField>, @public_ expected: ForeignGroup<ForeignField>) {
         console.dir(sg, { depth: null });
         let actual = sg.add(h);
-        let expected = new ForeignGroup(expected_x, expected_y);
+        console.log("expected.x class name", expected.x.constructor.name);
+        console.log("is expected.x instance of ForeignField", expected.x instanceof ForeignField);
         actual.assertEquals(expected);
     }
 }

--- a/verifier_circuit/src/verifier/verifier.ts
+++ b/verifier_circuit/src/verifier/verifier.ts
@@ -21,7 +21,7 @@ let { h } = SRS.createFromJSON();
 * Will contain information necessary for executing a verification
 */
 export class VerifierIndex {
-    srs: SRS<ForeignField>
+    srs: SRS
     domain_size: number
     domain_gen: Scalar
     /** number of public inputs */
@@ -131,11 +131,8 @@ export class Verifier extends Circuit {
     static readonly PERMUTATION_CONSTRAINTS: number = 3;
 
     @circuitMain
-    static main(@public_ sg: ForeignGroup<ForeignField>, @public_ expected: ForeignGroup<ForeignField>) {
-        console.dir(sg, { depth: null });
+    static main(@public_ sg: ForeignGroup, @public_ expected: ForeignGroup) {
         let actual = sg.add(h);
-        console.log("expected.x class name", expected.x.constructor.name);
-        console.log("is expected.x instance of ForeignField", expected.x instanceof ForeignField);
         actual.assertEquals(expected);
     }
 }

--- a/verifier_circuit/src/verifier/verifier.ts
+++ b/verifier_circuit/src/verifier/verifier.ts
@@ -7,6 +7,7 @@ import { Alphas } from '../alphas.js';
 import { Polynomial } from '../polynomial.js';
 import { Linearization, PolishToken } from '../prover/expr.js';
 import { ForeignField } from '../foreign_fields/foreign_field.js';
+import { ForeignScalar } from '../foreign_fields/foreign_scalar.js';
 
 let steps: bigint[][];
 try {
@@ -131,8 +132,31 @@ export class Verifier extends Circuit {
     static readonly PERMUTATION_CONSTRAINTS: number = 3;
 
     @circuitMain
-    static main(@public_ sg: ForeignGroup, @public_ expected: ForeignGroup) {
-        let actual = sg.add(h);
-        actual.assertEquals(expected);
+    static main(@public_ sg: ForeignGroup, @public_ z1: ForeignScalar, @public_ expected: ForeignGroup) {
+        let points = [h];
+        let scalars = [ForeignScalar.from(0)];
+
+        let randBase = ForeignScalar.from(1);
+        let sgRandBase = ForeignScalar.from(1);
+        let negRandBase = randBase.neg();
+
+        points.push(sg);
+        scalars.push(negRandBase.mul(z1).sub(sgRandBase));
+
+        let result = Verifier.naiveMSM(points, scalars);
+
+        result.assertEquals(expected);
+    }
+
+    static naiveMSM(points: ForeignGroup[], scalars: ForeignScalar[]): ForeignGroup {
+        let result = new ForeignGroup(ForeignField.from(0), ForeignField.from(0));
+
+        for (let i = 0; i < points.length; i++) {
+            let point = points[i];
+            let scalar = scalars[i];
+            result = result.add(point.scale(scalar));
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
- Uses the `ForeignGroup` operation gates
- Restores the Kimchi verifier circuit back to a minimum subset (instead of being only an addition of `ForeignField`s)