### PR TITLE
Move URS deserialization to measurable function

### DIFF
--- a/eth_verifier/script/Verify.s.sol
+++ b/eth_verifier/script/Verify.s.sol
@@ -23,13 +23,14 @@ contract Verify is Script {
         vm.startBroadcast(deployerPrivateKey);
 
         KimchiVerifier verifier = new KimchiVerifier();
-        verifier.setup(urs_serialized);
+        verifier.setup();
 
         bool success = verifier.verify_with_index(
             verifier_index_serialized,
             prover_proof_serialized,
             linearization_serialized_rlp,
-            public_inputs_serialized
+            public_inputs_serialized,
+            urs_serialized
         );
 
         require(success, "Verification failed.");

--- a/eth_verifier/src/Verifier.sol
+++ b/eth_verifier/src/Verifier.sol
@@ -48,9 +48,7 @@ contract KimchiVerifier {
     State internal state;
     bool state_available;
 
-    function setup(bytes memory urs_serialized) public {
-        MsgPk.deser_pairing_urs(MsgPk.new_stream(urs_serialized), urs);
-
+    function setup() public {
         // INFO: powers of alpha are fixed for a given constraint system, so we can hard-code them.
         verifier_index.powers_of_alpha.register(ArgumentType.GateZero, VARBASEMUL_CONSTRAINTS);
         verifier_index.powers_of_alpha.register(ArgumentType.Permutation, PERMUTATION_CONSTRAINTS);
@@ -64,22 +62,29 @@ contract KimchiVerifier {
         bytes calldata verifier_index_serialized,
         bytes calldata prover_proof_serialized,
         bytes calldata linearization_serialized_rlp,
-        bytes calldata public_inputs_serialized
+        bytes calldata public_inputs_serialized,
+        bytes memory urs_serialized
     ) public {
         MsgPk.deser_verifier_index(MsgPk.new_stream(verifier_index_serialized), verifier_index);
         deser_prover_proof(prover_proof_serialized, proof);
         verifier_index.linearization = abi.decode(linearization_serialized_rlp, (Linearization));
         public_inputs = MsgPk.deser_public_inputs(public_inputs_serialized);
+        MsgPk.deser_pairing_urs(MsgPk.new_stream(urs_serialized), urs);
     }
 
     function verify_with_index(
         bytes calldata verifier_index_serialized,
         bytes calldata prover_proof_serialized,
         bytes calldata linearization_serialized_rlp,
-        bytes calldata public_inputs_serialized
+        bytes calldata public_inputs_serialized,
+        bytes memory urs_serialized
     ) public returns (bool) {
         deserialize_proof(
-            verifier_index_serialized, prover_proof_serialized, linearization_serialized_rlp, public_inputs_serialized
+            verifier_index_serialized,
+            prover_proof_serialized,
+            linearization_serialized_rlp,
+            public_inputs_serialized,
+            urs_serialized
         );
         AggregatedEvaluationProof memory agg_proof = partial_verify();
         return final_verify(agg_proof);

--- a/eth_verifier/test/Verify.t.sol
+++ b/eth_verifier/test/Verify.t.sol
@@ -38,10 +38,14 @@ contract KimchiVerifierTest is Test {
     function test_verify_with_index() public {
         KimchiVerifier verifier = new KimchiVerifier();
 
-        verifier.setup(urs_serialized);
+        verifier.setup();
 
         bool success = verifier.verify_with_index(
-            verifier_index_serialized, prover_proof_serialized, linearization_serialized_rlp, public_inputs_serialized
+            verifier_index_serialized,
+            prover_proof_serialized,
+            linearization_serialized_rlp,
+            public_inputs_serialized,
+            urs_serialized
         );
 
         require(success, "Verification failed!");
@@ -50,10 +54,14 @@ contract KimchiVerifierTest is Test {
     function test_partial_verify() public {
         KimchiVerifier verifier = new KimchiVerifier();
 
-        verifier.setup(urs_serialized);
+        verifier.setup();
 
         verifier.deserialize_proof(
-            verifier_index_serialized, prover_proof_serialized, linearization_serialized_rlp, public_inputs_serialized
+            verifier_index_serialized,
+            prover_proof_serialized,
+            linearization_serialized_rlp,
+            public_inputs_serialized,
+            urs_serialized
         );
 
         AggregatedEvaluationProof memory agg_proof = verifier.partial_verify();
@@ -65,10 +73,14 @@ contract KimchiVerifierTest is Test {
     function test_eval_commitment() public {
         KimchiVerifier verifier = new KimchiVerifier();
 
-        verifier.setup(urs_serialized);
+        verifier.setup();
 
         verifier.deserialize_proof(
-            verifier_index_serialized, prover_proof_serialized, linearization_serialized_rlp, public_inputs_serialized
+            verifier_index_serialized,
+            prover_proof_serialized,
+            linearization_serialized_rlp,
+            public_inputs_serialized,
+            urs_serialized
         );
 
         Scalar.FE[2] memory evaluation_points = [
@@ -97,10 +109,14 @@ contract KimchiVerifierTest is Test {
     function test_divisor_commitment() public {
         KimchiVerifier verifier = new KimchiVerifier();
 
-        verifier.setup(urs_serialized);
+        verifier.setup();
 
         verifier.deserialize_proof(
-            verifier_index_serialized, prover_proof_serialized, linearization_serialized_rlp, public_inputs_serialized
+            verifier_index_serialized,
+            prover_proof_serialized,
+            linearization_serialized_rlp,
+            public_inputs_serialized,
+            urs_serialized
         );
 
         Scalar.FE[2] memory evaluation_points = [
@@ -117,10 +133,14 @@ contract KimchiVerifierTest is Test {
     function test_public_commitment() public {
         KimchiVerifier verifier = new KimchiVerifier();
 
-        verifier.setup(urs_serialized);
+        verifier.setup();
 
         verifier.deserialize_proof(
-            verifier_index_serialized, prover_proof_serialized, linearization_serialized_rlp, public_inputs_serialized
+            verifier_index_serialized,
+            prover_proof_serialized,
+            linearization_serialized_rlp,
+            public_inputs_serialized,
+            urs_serialized
         );
 
         BN254.G1Point memory public_commitment = verifier.public_commitment();


### PR DESCRIPTION
For some reason, `setup()` is not taken into account for gas measurement. `setup()` includes URS deserialization, so in this PR we move URS deserialization into a function that is taken into account.