### PR TITLE
Fix Aligned SDK dependency

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,7 +22,7 @@ ark-poly = { version = "0.3.0", features = ["parallel"] }
 ark-serialize = "0.3.0"
 mina-tree = { git = "https://github.com/lambdaclass/openmina/", branch = "mina_bridge" }
 mina-p2p-messages = { git = "https://github.com/lambdaclass/openmina/", branch = "mina_bridge" }
-aligned-sdk = { git = "https://github.com/lambdaclass/aligned_layer.git", branch = "update_to_0_6" }
+aligned-sdk = { git = "https://github.com/lambdaclass/aligned_layer.git", branch = "mina" }
 ethers = { tag = "v2.0.15-fix-reconnections", features = [
   "ws",
   "rustls",


### PR DESCRIPTION
Currently points to the `update_to_0_6` branch which no longer exists