### PR TITLE
chore: bump deps

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,8 +20,8 @@ ark-ff = { version = "0.3.0", features = ["parallel", "asm"] }
 ark-ec = { version = "0.3.0", features = ["parallel"] }
 ark-poly = { version = "0.3.0", features = ["parallel"] }
 ark-serialize = "0.3.0"
-mina-tree = { git = "https://github.com/lambdaclass/openmina/", rev = "860a55dde0e2943c9437ebdfdecbee5f1ac4976f" }
-mina-p2p-messages = { git = "https://github.com/lambdaclass/openmina/", rev = "860a55dde0e2943c9437ebdfdecbee5f1ac4976f" }
+mina-tree = { git = "https://github.com/lambdaclass/openmina/", rev = "97df7ca5e3b631c99c9fa23a9ff8c76b4120504c" }
+mina-p2p-messages = { git = "https://github.com/lambdaclass/openmina/", rev = "97df7ca5e3b631c99c9fa23a9ff8c76b4120504c" }
 aligned-sdk = { git = "https://github.com/lambdaclass/aligned_layer.git", rev = "220546afa12c035a508529224f5148cd6af4ca78" }
 ethers = { version = "2.0", features = ["ws", "rustls"] }
 rpassword = "7.3.1"


### PR DESCRIPTION
Update mina deps to point to the latest commit of the fork, see [here](https://github.com/lambdaclass/openmina/commit/97df7ca5e3b631c99c9fa23a9ff8c76b4120504c).